### PR TITLE
GAで各ページのpathでトラッキングできるようにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem 'jbuilder', '~> 2.5'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
+gem 'google-analytics-rails'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
     ffi (1.10.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    google-analytics-rails (1.1.1)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
@@ -199,6 +200,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   chromedriver-helper
   coffee-rails (~> 4.2)
+  google-analytics-rails
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   pg (~> 1.1.4)

--- a/app/helpers/google_analytics_helper.rb
+++ b/app/helpers/google_analytics_helper.rb
@@ -1,0 +1,7 @@
+module GoogleAnalyticsHelper
+  def track_page
+    return unless Rails.env.production?
+
+    analytics_init(page: request.fullpath)
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,8 @@
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+
+    <%= analytics_init if Rails.env.production?%>
   </head>
 
   <body>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,5 @@
+<%= track_page %>
+
 <p id="notice"><%= notice %></p>
 
 <p>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,4 +91,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  GA.tracker = ENV['SAMPLE_GA_RAILS_TRACKING_ID']
 end


### PR DESCRIPTION
# 概要

`google-analytics-rails` でapplication テンプレートに`analytics_init`を仕込むだけだとpage viewが計測でなかったので計測できるように`page`オプションを設定した
